### PR TITLE
Bump scipy from 1.16.1 -> 1.16.3

### DIFF
--- a/org.sasview.sasview.yml
+++ b/org.sasview.sasview.yml
@@ -172,3 +172,4 @@ modules:
       - type: git
         url: "https://github.com/SasView/sasview.git"
         tag: "v6.1.2.post1"
+

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -3133,8 +3133,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/f5/4a/b927028464795439faec8eaf0b03b011005c487bb2d07409f28bf30879c4/scipy-1.16.3.tar.gz",
-                    "sha256": "44c76f9e8b6e8e488a586190ab38016e4ed2f8a038af7cd3defa903c0a2238b3"
+                    "url": "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz",
+                    "sha256": "01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb"
                 }
             ]
         },

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -3128,12 +3128,12 @@
             "name": "python3-scipy",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"scipy==1.16.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"scipy==1.16.3\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/f5/4a/b927028464795439faec8eaf0b03b011005c487bb2d07409f28bf30879c4/scipy-1.16.1.tar.gz",
+                    "url": "https://files.pythonhosted.org/packages/f5/4a/b927028464795439faec8eaf0b03b011005c487bb2d07409f28bf30879c4/scipy-1.16.3.tar.gz",
                     "sha256": "44c76f9e8b6e8e488a586190ab38016e4ed2f8a038af7cd3defa903c0a2238b3"
                 }
             ]


### PR DESCRIPTION
Looking through the logs for the v6.1.2 Flatpak release, the same message noted in https://github.com/SasView/sasview/issues/3858 also appears. Reading through the [release notes for scipy 1.16.2](https://docs.scipy.org/doc/scipy/release/1.16.2-notes.html), there was an issue with scikit-umfpack. This issue was fixed in v1.16.3 of scipy, so I'm hoping bumping scipy fixes the issue.

To test, I'll download the logs once the build completes (assuming it's successful) and look for the errors I saw in the logs in https://github.com/flathub-infra/vorarbeiter/actions/runs/20762467127.