### PR TITLE
SasView Release v6.1.3

### DIFF
--- a/org.sasview.sasview.yml
+++ b/org.sasview.sasview.yml
@@ -176,5 +176,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/SasView/sasview.git
-        tag: v6.1.2.post1
-
+        branch: release-6.1.3

--- a/org.sasview.sasview.yml
+++ b/org.sasview.sasview.yml
@@ -176,4 +176,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/SasView/sasview.git
-        branch: release-6.1.3
+        commit: 23d8c7dd75d171b255169e2ad774fee303d6f436

--- a/org.sasview.sasview.yml
+++ b/org.sasview.sasview.yml
@@ -176,4 +176,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/SasView/sasview.git
-        commit: 23d8c7dd75d171b255169e2ad774fee303d6f436
+        tag: v6.1.3


### PR DESCRIPTION
This is a test to be sure the build is successful. Before merging, `org.sasview.sasview.yml` should be changed back to using the tag and `v6.1.3` once that tag exists.